### PR TITLE
Korjaa sortatun tuloslistan filterointi

### DIFF
--- a/src/mahjongtilasto/gui/gui_tulostilastot.py
+++ b/src/mahjongtilasto/gui/gui_tulostilastot.py
@@ -108,6 +108,7 @@ class TulosTilastot(QtWidgets.QDialog):
         '''Täytä pelaajatilastot taulukkoon.
         '''
         self.tayta_pelaajastats()
+        self.taulukko.setSortingEnabled(False)
         self.taulukko.setRowCount(len(self.pelaajastats))
 
         for row, pelaaja in enumerate(self.pelaajastats):
@@ -136,6 +137,7 @@ class TulosTilastot(QtWidgets.QDialog):
             per_peli.setData(QtCore.Qt.DisplayRole, keskimaarin)
             self.taulukko.setItem(row, 5, per_peli)
 
+        self.taulukko.setSortingEnabled(True)
         # Säädä ikkunan koko sopivaksi
         taulukon_leveys = self.taulukko.verticalHeader().width() + 4
         for colind in range(self.taulukko.columnCount()):

--- a/src/mahjongtilasto/gui/gui_tulostilastot.py
+++ b/src/mahjongtilasto/gui/gui_tulostilastot.py
@@ -24,6 +24,7 @@ class TulosTilastot(QtWidgets.QDialog):
 
         self.centralwidget = QtWidgets.QWidget(self)
         self.layout = QtWidgets.QVBoxLayout(self)
+        self.margins = self.layout.contentsMargins()
 
         # Valinta aikaikkunalle (mitkä pelit otetaan mukaan)
         self.aikadelta = None # kaikki
@@ -138,15 +139,21 @@ class TulosTilastot(QtWidgets.QDialog):
             self.taulukko.setItem(row, 5, per_peli)
 
         self.taulukko.setSortingEnabled(True)
-        # Säädä ikkunan koko sopivaksi
-        taulukon_leveys = self.taulukko.verticalHeader().width() + 4
+        self.saada_koko()
+
+    def saada_koko(self):
+        '''Säädä ikkunan koko sopivaksi
+        '''
+        taulukon_leveys = self.taulukko.verticalHeader().width() + 4 + self.margins.left() + self.margins.right()
         for colind in range(self.taulukko.columnCount()):
             taulukon_leveys += self.taulukko.columnWidth(colind)
         LOGGER.debug("Taulukon leveys %s", taulukon_leveys)
-        taulukon_korkeus = self.taulukko.horizontalHeader().height() + 24
+
+        taulukon_korkeus = self.taulukko.horizontalHeader().height() + 24 + self.margins.top() + self.margins.bottom()
         for rowind in range(self.taulukko.rowCount()):
             taulukon_korkeus += self.taulukko.rowHeight(rowind)
         LOGGER.debug("Taulukon korkeus %s", taulukon_korkeus)
+
         self.resize(min(800, taulukon_leveys), min(800, taulukon_korkeus))
 
     def vaihda_aikaikkunaa(self):

--- a/src/mahjongtilasto/parseri.py
+++ b/src/mahjongtilasto/parseri.py
@@ -310,8 +310,10 @@ def pelaajadeltat(tiedostopolku: str, jalkeen_ajan=None, ennen_aikaa=None):
                         LOGGER.debug("Mutta myös ennen '%s', skip",
                             ennen_aikaa.strftime("%Y-%m-%d"))
                     else:
-                        LOGGER.debug("Ja jälkeen '%s', ok",
-                            ennen_aikaa.strftime("%Y-%m-%d"))
+                        # debugit kaatais ohjelman jos ennen_aikaa on None...
+                        if isinstance(ennen_aikaa, datetime.date):
+                            LOGGER.debug("Ja jälkeen '%s', ok",
+                                ennen_aikaa.strftime("%Y-%m-%d"))
                         mukaan_tuloksiin = True
                 else:
                     LOGGER.debug("'%s' on ennen '%s', skip",


### PR DESCRIPTION
Jos tuloslistan järjesti jonkun sarakkeen mukaan, tulosten aikafilterin vaihtaminen johti ihan huuhaa-tuloksiin (alla esimerkki)

<details>
<summary> Kuvat ja repro mainitusta bugista </summary>

Reproutuu avaamalla tuloslista, järjestämällä jonkun sarakkeen mukaan (paitsi totaalipisteet, koska ne on valmiiksi siinä järkässä), ja vaihtamalla aikarajoitusta.

![oikea sisältö tulostaulussa](https://github.com/user-attachments/assets/08e6f43b-abc1-4fe4-8822-fa4ae2769559)
_Toivotut tulokset (ei sortattu)_

![huuhaa-sisältöä](https://github.com/user-attachments/assets/4b64314f-b96d-4c02-b9f3-eea9ef417ebb)
_Bugiset tulokset (Pelaaja 2 ja 5 kahteen kertaan, väärä määrä pelejä (esim. oikeassa tuloslistassa on kaksi 1-peli pelaajaa; tässä kaksi 2-peli ja yksi 1-peli)_
</details>

Bugi johtuu siitä, että Qt (ilmeisesti) automaagisesti sorttaa tablen kesken näiden tulosten päivittelyn (koska päivitellään rivi kerrallaan solu kerrallaan, jne), jolloin muokattavat rivit ei ole aina siinä, missä niiden oletetaan olevan.
Korjataan tämä estämällä sorttaus tablea muuttaessa, ja laittamalla se takaisin käyttöön tämän jälkeen.
